### PR TITLE
feat(node-lts-ci): replace claude code cli with uv

### DIFF
--- a/node-lts-ci/24-noble/Dockerfile
+++ b/node-lts-ci/24-noble/Dockerfile
@@ -67,8 +67,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     wrangler \
     ibm-openapi-validator \
     @socketsecurity/cli \
-  # Claude Code CLI
-  && curl -fsSL https://claude.ai/install.sh | bash \
+  # uv (Python package manager)
+  && curl -LsSf https://astral.sh/uv/install.sh | sh \
   # Cleanup layer
   && rm -rf /var/lib/apt/lists/* \
   # Smoke test
@@ -79,4 +79,4 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && kubectl version --client \
   && gcloud --version \
   && mongosh --version \
-  && claude --version
+  && uv --version


### PR DESCRIPTION
Replace Claude Code CLI (doesn't support Linux) with uv Python package manager from Astral.